### PR TITLE
Add browser-based voice MVP with pastel UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # voiceapp
+
+Minimal MVP that converts text into speech using the browser's Web Speech API.
+
+## Usage
+
+Open `index.html` in a modern browser, type your text, choose a voice and press **Speak**. The interface uses bright pastel colors for a friendly feel.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Voice App MVP</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="container">
+      <h1>Voice App MVP</h1>
+      <textarea id="text" placeholder="Type text here..."></textarea>
+      <div class="controls">
+        <select id="voiceSelect"></select>
+        <button id="speakBtn">Speak</button>
+      </div>
+    </div>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,32 @@
+const synth = window.speechSynthesis;
+const voiceSelect = document.getElementById("voiceSelect");
+const textInput = document.getElementById("text");
+const speakBtn = document.getElementById("speakBtn");
+
+function populateVoices() {
+  const voices = synth.getVoices();
+  voiceSelect.innerHTML = "";
+  voices.forEach((voice) => {
+    const option = document.createElement("option");
+    option.textContent = `${voice.name} (${voice.lang})`;
+    option.setAttribute("data-name", voice.name);
+    voiceSelect.appendChild(option);
+  });
+}
+
+populateVoices();
+if (speechSynthesis.onvoiceschanged !== undefined) {
+  speechSynthesis.onvoiceschanged = populateVoices;
+}
+
+speakBtn.addEventListener("click", () => {
+  const text = textInput.value.trim();
+  if (!text) return;
+  const utterance = new SpeechSynthesisUtterance(text);
+  const selectedName = voiceSelect.selectedOptions[0].getAttribute("data-name");
+  const voice = synth.getVoices().find((v) => v.name === selectedName);
+  if (voice) {
+    utterance.voice = voice;
+  }
+  synth.speak(utterance);
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,69 @@
+:root {
+  --bg-start: #fff1eb;
+  --bg-end: #ace0f9;
+  --accent: #ffb3c1;
+  --accent-dark: #ff6392;
+}
+
+body {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: linear-gradient(135deg, var(--bg-start), var(--bg-end));
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.container {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  width: min(90%, 600px);
+}
+
+h1 {
+  text-align: center;
+  color: #333;
+  margin-bottom: 1rem;
+}
+
+textarea {
+  width: 100%;
+  height: 150px;
+  padding: 1rem;
+  border: 2px solid var(--accent);
+  border-radius: 0.5rem;
+  resize: vertical;
+}
+
+.controls {
+  display: flex;
+  margin-top: 1rem;
+  gap: 0.5rem;
+}
+
+select,
+button {
+  flex: 1;
+  padding: 0.75rem;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+}
+
+select {
+  background: #f0f0f0;
+}
+
+button {
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+button:hover {
+  background: var(--accent-dark);
+}


### PR DESCRIPTION
## Summary
- Add `index.html`, `style.css`, and `script.js` implementing a text‑to‑speech MVP using the browser's Web Speech API
- Style the page with bright pastel colors and simple controls
- Document usage in the README

## Testing
- `npx --yes prettier@3.2.5 --write index.html style.css script.js README.md` *(fails: 403 Forbidden from npm registry)*
- `python -m py_compile $(git ls-files '*.py')` *(fails: the following arguments are required: filenames)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3f9f4ba8832789745efcf0f1b944